### PR TITLE
Add the pistachio path parameter to cached file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 MANIFEST
 dist/
 build/
+.idea

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ value = config['some_key']
 #### Under the Hood
 When you run `pistachio.load()` it:  
 - Checks if you have a 'cache' setting
-  - If so, attepmpts to load from the cache file, if it exists
+  - If so, checks that `path` setting matches Pistachios `path` value in the cache file, if it exists
+  - If so, attempts to load from the cache file, if it exists
 - Otherwise, loads the config by merging yaml files from specified bucket/folders
   - This can be slow, as it has to download each file from S3 over the network
 - If 'cache' is set, saves the cache

--- a/pistachio/cache.py
+++ b/pistachio/cache.py
@@ -2,20 +2,36 @@ import os
 import time
 import yaml
 
+
 # Attempt to load cache from cache_path
-def load(cache):
+def load(settings):
+  if not settings.get('cache'):
+    return None
+
+  cache = settings['cache']
   # Load the file from a cache if one exists and not expired
   if ((cache.get('path', None) and os.path.isfile(cache['path'])) and
      cache.get('enabled', True) and
      ('expires' not in cache or not is_expired(cache))):
-    return yaml.load(open(cache['path'],'r'))
+    loaded = yaml.load(open(cache['path'], 'r'))
+
+    # If path exists in settings and cached file and both values don't match - cache is invalid
+    if settings.get('path') and loaded['pistachio'].get('path') and settings['path'] != loaded['pistachio']['path']:
+      return None
+
+    return loaded
 
   # Otherwise return None
   return None
 
 
 # Write cache to cache_path
-def write(cache, config):
+def write(settings, config):
+  if not settings.get('cache'):
+    return None
+  cache = settings['cache']
+  if settings.get('path') and config.get('pistachio'):
+    config['pistachio']['path'] = settings['path']
   if cache.get('path', None) and cache['enabled']:
     with open(cache['path'], 'w') as pistachio_cache:
       pistachio_cache.write( yaml.safe_dump(config, default_flow_style=False))

--- a/pistachio/main.py
+++ b/pistachio/main.py
@@ -16,14 +16,14 @@ def load(s=SETTINGS):
   s = settings.validate(s)
 
   # Attempt to load from cache unless disabled
-  loaded_cache = cache.load(s['cache'])
+  loaded_cache = cache.load(s)
   if loaded_cache is not None:
     return loaded_cache
 
   # Otherwise, download from s3, and save to cache
   conn = s3.create_connection(s)
   loaded = s3.download(conn, s['bucket'], s['path'], s['parallel'])
-  cache.write(s['cache'], loaded)
+  cache.write(s, loaded)
 
   # Memoize
   memo = loaded
@@ -39,7 +39,7 @@ def attempt_reload(s=SETTINGS):
   try:
     conn = s3.create_connection(s)
     loaded = s3.download(conn, s['bucket'], s['path'], s['parallel'])
-    cache.write(s['cache'], loaded)
+    cache.write(s, loaded)
     # Memoize
     global memo
     memo = loaded

--- a/test/cache_test.py
+++ b/test/cache_test.py
@@ -47,24 +47,29 @@ class TestLoad(unittest.TestCase):
     test_cache = {}
     self.assertEqual(cache.load(test_cache), None)
 
+  # Test that cache is ignored when empty
+  def test_cache_no_settings(self):
+    test_cache = {'cache': {}}
+    self.assertEqual(cache.load(test_cache), None)
+
   # Test that cache is ignored when expired
   def test_cache_expired(self):
-    test_cache = {'path': 'exists', 'expires': 1} # 1 minute
+    test_cache = {'cache': {'path': 'exists', 'expires': 1}} # 1 minute
     self.assertEqual(cache.load(test_cache), None)
 
   # Test that cache is loaded when not expired
   def test_cache_not_expired(self):
-    test_cache = {'path': 'exists', 'expires': 3} # 3 minute
+    test_cache = {'cache': {'path': 'exists', 'expires': 3}} # 3 minute
     self.assertEqual(cache.load(test_cache), {'foo': 'bar'})
 
   # Test that cache is loaded when no expired is specified
   def test_cache_no_expires_setting(self):
-    test_cache = {'path': 'exists'}
+    test_cache = {'cache': {'path': 'exists'}}
     self.assertEqual(cache.load(test_cache), {'foo': 'bar'})
 
   # Test that cache is ignored when no disabled
   def test_cache_disabled(self):
-    test_cache = {'path': 'exists', 'enabled': False}
+    test_cache = {'cache': {'path': 'exists', 'enabled': False}}
     self.assertEqual(cache.load(test_cache), None)
 
 
@@ -85,21 +90,21 @@ class TestWrite(unittest.TestCase):
   # Test that cache is not written when no path is set
   @mock.patch.object(builtins_module, 'open')
   def test_cache_not_set(self, open_mock):
-    test_cache = {}
+    test_cache = {'cache': {}}
     cache.write(test_cache, self.test_config)
     self.assertFalse(open_mock.called)
 
   # Test that cache is written when path is set and enabled is set to true
   @mock.patch.object(builtins_module, 'open')
   def test_cache_enabled_true(self, open_mock):
-    test_cache = {'path': 'exists', 'enabled': True}
+    test_cache = {'cache': {'path': 'exists', 'enabled': True}}
     cache.write(test_cache, self.test_config)
     self.assertTrue(open_mock.called)
 
   # Test that cache is not written when path is set and enabled is set to false
   @mock.patch.object(builtins_module, 'open')
   def test_cache_enabled_true(self, open_mock):
-    test_cache = {'path': 'exists', 'enabled': False}
+    test_cache = {'cache': {'path': 'exists', 'enabled': False}}
     cache.write(test_cache, self.test_config)
     self.assertFalse(open_mock.called)
 

--- a/test/main_test.py
+++ b/test/main_test.py
@@ -7,11 +7,13 @@ import pistachio.main
 
 TEST_CONFIG = {
   'test': 'config',
+  'pistachio': {}
 }
 TEST_SETTINGS = {
   'key': 'test',
   'secret': 'test',
   'bucket': 'test',
+  'path': 'test',
 }
 
 # Tests the settings.validate function
@@ -42,9 +44,9 @@ class TestMemoization(unittest.TestCase):
     self.assertEqual(pistachio.main.memo, TEST_CONFIG)
 
   # Test that memo is not loaded on a reload
-  @mock.patch('pistachio.s3.download', mock.Mock(return_value = {'fraudulent': 'config'}))
+  @mock.patch('pistachio.s3.download', mock.Mock(return_value = {'fraudulent': 'config', 'pistachio': {}}))
   def test_reload_ignores_memo(self):
-    pistachio.main.attempt_reload(TEST_SETTINGS)
+    print pistachio.main.attempt_reload(TEST_SETTINGS)
     self.assertNotEqual(pistachio.main.memo, TEST_CONFIG)
 
 


### PR DESCRIPTION
Brief presentation about the problem - https://docs.google.com/presentation/d/1FwEkUbW5f17AvYwghpUaT5CNhXrwBBG0bL8vIwdj65I/edit#slide=id.p

The fix adds the pistachio path parameter to cached file on cache.write() operation.

On cache.load() operation, stored in cached file pistachio.cache parameter is compared to current path settings and if they are different - cached file is ignored.

That prevents us from using invalid cache files for different environments.