### PR TITLE
Moving to setuptools so we can have dependencies and whatnot

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,6 @@ setup(
   description='Credential Loader for S3 Stored Credentials',
   long_description=open('README.rst').read(),
   install_requires=INSTALL_REQUIRES,
-  test_requires=TEST_REQUIRES,
+  tests_require=TEST_REQUIRES,
+  test_suite='test',
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 VERSION = open('VERSION').read().strip()
 with open('requirements/core.txt') as f:


### PR DESCRIPTION
Moving form distutils to setuptools should literally just be an import change.  Now's a good time to get this in, since there's about to be a major version bump.